### PR TITLE
T2191 - Acertos para NF 4.0 Venda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-- "3.4"
-- "3.5"
 - "3.6"
 virtual_env:
   system_site_packages: true

--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -536,6 +536,7 @@
                             <CSOSN>{{ imposto.ICMS.CST }}</CSOSN>
                             <vBCSTRet>{{ imposto.ICMS.vBCSTRet }}</vBCSTRet>
                             <pST>{{ imposto.ICMS.pST }}</pST>
+                            <vICMSSubstituto>{{ imposto.ICMS.vICMSSubstituto }}</vICMSSubstituto>
                             <vICMSSTRet>{{ imposto.ICMS.vICMSSTRet }}</vICMSSTRet>
                             <vBCFCPSTRet>{{ imposto.ICMS.vBCFCPSTRet }}</vBCFCPSTRet>
                             <pFCPSTRet>{{ imposto.ICMS.pFCPSTRet }}</pFCPSTRet>

--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -477,9 +477,18 @@
                             <orig>{{ imposto.ICMSST.orig }}</orig>
                             <CST>{{ imposto.ICMSST.CST }}</CST>
                             <vBCSTRet>{{ imposto.ICMSST.vBCSTRet }}</vBCSTRet>
+                            <pST>{{ imposto.ICMSST.pST }}</pST>
+                            <vICMSSubstituto>{{ imposto.ICMSST.vICMSSubstituto }}</vICMSSubstituto>
                             <vICMSSTRet>{{ imposto.ICMSST.vICMSSTRet }}</vICMSSTRet>
+                            <vBCFCPSTRet>{{ imposto.ICMSST.vBCFCPSTRet }}</vBCFCPSTRet>
+                            <pFCPSTRet>{{ imposto.ICMSST.pFCPSTRet }}</pFCPSTRet>
+                            <vFCPSTRet>{{ imposto.ICMSST.vFCPSTRet }}</vFCPSTRet>
                             <vBCSTDest>{{ imposto.ICMSST.vBCSTDest }}</vBCSTDest>
                             <vICMSSTDest>{{ imposto.ICMSST.vICMSSTDest }}</vICMSSTDest>
+                            <pRedBCEfet>{{ imposto.ICMSST.pRedBCEfet }}</pRedBCEfet>
+                            <vBCEfet>{{ imposto.ICMSST.vBCEfet }}</vBCEfet>
+                            <pICMSEfet>{{ imposto.ICMSST.pICMSEfet }}</pICMSEfet>
+                            <vICMSEfet>{{ imposto.ICMSST.vICMSEfet }}</vICMSEfet>
                         </ICMSST>
                         {% endif %}
                         {% if imposto.ICMS.CST == '101' -%}

--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -385,6 +385,7 @@
                             <CST>{{ imposto.ICMS.CST }}</CST>
                             <vBCSTRet>{{ imposto.ICMS.vBCSTRet }}</vBCSTRet>
                             <pST>{{ imposto.ICMS.pST }}</pST>
+                            <vICMSSubstituto>{{ imposto.ICMS.vICMSSubstituto }}</vICMSSubstituto>
                             <vICMSSTRet>{{ imposto.ICMS.vICMSSTRet }}</vICMSSTRet>
                             <vBCFCPSTRet>{{ imposto.ICMS.vBCFCPSTRet }}</vBCFCPSTRet>
                             <pFCPSTRet>{{ imposto.ICMS.pFCPSTRet }}</pFCPSTRet>

--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -141,6 +141,7 @@
             <retirada>
                 <CNPJ>{{ NFe.infNFe.retirada.CNPJ }}</CNPJ>
                 <CPF>{{ NFe.infNFe.retirada.CPF }}</CPF>
+                <xNome>{{ NFe.infNFe.retirada.xNome }}</xNome>
                 <xLgr>{{ NFe.infNFe.retirada.xLgr|normalize|escape }}</xLgr>
                 <nro>{{ NFe.infNFe.retirada.nro }}</nro>
                 <xCpl>{{ NFe.infNFe.retirada.xCpl|normalize|escape }}</xCpl>
@@ -148,6 +149,12 @@
                 <cMun>{{ NFe.infNFe.retirada.cMun }}</cMun>
                 <xMun>{{ NFe.infNFe.retirada.xMun|normalize }}</xMun>
                 <UF>{{ NFe.infNFe.retirada.UF }}</UF>
+                <CEP>{{ NFe.infNFe.retirada.CEP }}</CEP>
+                <cPais>{{ NFe.infNFe.retirada.cPais }}</cPais>
+                <xPais>{{ NFe.infNFe.retirada.xPais }}</xPais>
+                <fone>{{ NFe.infNFe.retirada.fone }}</fone>
+                <email>{{ NFe.infNFe.retirada.email }}</email>
+                <IE>{{ NFe.infNFe.retirada.IE }}</IE>
             </retirada>
             {% endif %}
             {% if NFe.infNFe.entrega is defined %}

--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -154,6 +154,7 @@
             <entrega>
                 <CNPJ>{{ NFe.infNFe.entrega.CNPJ }}</CNPJ>
                 <CPF>{{ NFe.infNFe.entrega.CPF }}</CPF>
+                <xNome>{{ NFe.infNFe.entrega.xNome }}</xNome>
                 <xLgr>{{ NFe.infNFe.entrega.xLgr|normalize|escape }}</xLgr>
                 <nro>{{ NFe.infNFe.entrega.nro }}</nro>
                 <xCpl>{{ NFe.infNFe.entrega.xCpl|normalize|escape }}</xCpl>
@@ -161,6 +162,12 @@
                 <cMun>{{ NFe.infNFe.entrega.cMun }}</cMun>
                 <xMun>{{ NFe.infNFe.entrega.xMun }}</xMun>
                 <UF>{{ NFe.infNFe.entrega.UF }}</UF>
+                <CEP>{{ NFe.infNFe.entrega.CEP }}</CEP>
+                <cPais>{{ NFe.infNFe.entrega.cPais }}</cPais>
+                <xPais>{{ NFe.infNFe.entrega.xPais }}</xPais>
+                <fone>{{ NFe.infNFe.entrega.fone }}</fone>
+                <email>{{ NFe.infNFe.entrega.email }}</email>
+                <IE>{{ NFe.infNFe.entrega.IE }}</IE>
             </entrega>
             {% endif %}
             {% if NFe.infNFe.autXML %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ certifi >= 2015.11.20.1
 xmlsec >= 1.3.3
 reportlab
 pytest
-pytest-cov
+pytest-cov==2.6.0
 pytz
 zeep


### PR DESCRIPTION
# Descrição

Ajustes da NFe 4.0 - NT2018-20005_v1_30

* Adiciona endereço de entrega
* Adiciona endereço de retirada
* Adiciona novos campos de Fundo de Combate a Pobreza (somente XML). - Necessário verificar estrutura dos impostos ICMS ST no código (aparentemente, há campos faltando).

# Informações adicionais

PR relacionado: https://github.com/multidadosti-erp/odoo-brasil-addons/pull/234

[T2191](https://multi.multidadosti.com.br/web#id=2600&view_type=form&model=project.task&action=323&active_id=61)
