### PR TITLE
Corrige url de homolog. da NFSe Carioca

### DIFF
--- a/pytrustnfe/nfse/carioca/__init__.py
+++ b/pytrustnfe/nfse/carioca/__init__.py
@@ -29,7 +29,7 @@ def _send(certificado, method, **kwargs):
     if kwargs["ambiente"] == "producao":
         base_url = "https://notacarioca.rio.gov.br/WSNacional/nfse.asmx?wsdl"
     else:
-        base_url = "https://homologacao.notacarioca.rio.gov.br/WSNacional/nfse.asmx?wsdl"  # noqa
+        base_url = "https://notacariocahom.rio.gov.br/WSNacional/nfse.asmx?wsdl"  # noqa
 
     xml_send = kwargs["xml"].decode("utf-8")
     cert, key = extract_cert_and_key_from_pfx(certificado.pfx, certificado.password)


### PR DESCRIPTION
# Descrição

* Corrige url de homolog. da NFSe Carioca

# Informações adicionais

Dados da tarefa: [T6353](https://multi.multidados.tech/web#id=6762&action=323&active_id=61&model=project.task&view_type=form&menu_id=)
