### PR TITLE
T6445 - Tratar retorno de consulta do sefaz fora do ar

### DIFF
--- a/pytrustnfe/Servidores.py
+++ b/pytrustnfe/Servidores.py
@@ -246,7 +246,6 @@ UFAM = {
             WS_NFE_RECEPCAO_EVENTO: "services2/services/RecepcaoEvento4?wsdl",
             WS_NFE_AUTORIZACAO: "services2/services/NfeAutorizacao4?wsdl",
             WS_NFE_RET_AUTORIZACAO: "services2/services/NfeRetAutorizacao4?wsdl",  # noqa
-            WS_NFE_CADASTRO: "services2/services/cadconsultacadastro2?wsdl",
         },
         AMBIENTE_HOMOLOGACAO: {
             "servidor": "homnfe.sefaz.am.gov.br",
@@ -256,7 +255,6 @@ UFAM = {
             WS_NFE_RECEPCAO_EVENTO: "services2/services/RecepcaoEvento4?wsdl",
             WS_NFE_AUTORIZACAO: "services2/services/NfeAutorizacao4?wsdl",
             WS_NFE_RET_AUTORIZACAO: "services2/services/NfeRetAutorizacao4?wsdl",  # noqa
-            WS_NFE_CADASTRO: "services2/services/cadconsultacadastro2?wsdl",
         },
     },
     NFCE_MODELO: {


### PR DESCRIPTION
# Descrição

* [FIX] O estado do AM não possui consulta de cadastro do SEFAZ

A partir da v4.0 da NFe, a consulta de cadastro foi para o estado do Amazonas foi removida

# Informações adicionais

Dados da tarefa: [T6445](https://multi.multidados.tech/web#id=6854&action=323&active_id=61&model=project.task&view_type=form&menu_id=)
