### PR TITLE
T5888 - Incluir Campo Xped e nItemPed para notas fiscais

### DIFF
--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -266,8 +266,8 @@
                     </detExport>
                     {% endfor %}
                     {% endif %}
-                    <xPed>{{ prod.xPed }}</xPed>
-                    <nItemPed>{{ prod.nItemPed }}</nItemPed>
+                    {% if prod.xPed %}<xPed>{{ prod.xPed }}</xPed>{% endif %}
+                    {% if prod.nItemPed %}<nItemPed>{{ prod.nItemPed }}</nItemPed>{% endif %}
                     <nFCI>{{ prod.nFCI }}</nFCI>
                     {% for rastro in prod.rastro %}
                     <rastro>


### PR DESCRIPTION
# Descrição

* Ajusta inclusão das tags 'xPed' e 'nItemPed'

# Informações adicionais

Dados da tarefa: [T5888](https://multi.multidados.tech/web?#id=6297&action=328&model=project.task&view_type=form&menu_id=223)
