### PR TITLE
T7890 - Emissão de NFS-e Fortaleza

### DIFF
--- a/pytrustnfe/nfse/ginfes/templates/CancelarNfse.xml
+++ b/pytrustnfe/nfse/ginfes/templates/CancelarNfse.xml
@@ -1,0 +1,7 @@
+<CancelarNfseEnvio xmlns="http://www.ginfes.com.br/servico_cancelar_nfse_envio" xmlns:tipos="http://www.ginfes.com.br/tipos">
+    <Prestador>
+      <tipos:Cnpj>{{ cancelamento.cnpj_prestador }}</tipos:Cnpj>
+      <tipos:InscricaoMunicipal>{{ cancelamento.inscricao_municipal }}</tipos:InscricaoMunicipal>
+    </Prestador>
+    <NumeroNfse>{{ cancelamento.numero_nfse }}</NumeroNfse>
+</CancelarNfseEnvio>


### PR DESCRIPTION
# Descrição

* Corrige envio de ginfes para municipio de Fortaleza

Ginfes de Fortaleza utiliza URL diferentes para os ambientes de homologação/produção e tambem possui serviço de cancelamento de NFSe com outro nome

# Informações adicionais

Dados da tarefa: [T7890](https://multi.multidados.tech/web?#id=8299&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

