### PR TITLE
T8096 - Corrige erro de emissão de NFe

### DIFF
--- a/pytrustnfe/nfe/__init__.py
+++ b/pytrustnfe/nfe/__init__.py
@@ -50,14 +50,18 @@ def _render(certificado, method, sign, **kwargs):
 
     if sign:
         signer = Assinatura(certificado.pfx, certificado.password)
+
         if method == "NfeInutilizacao":
             xml_send = signer.assina_xml(xmlElem_send, kwargs["obj"]["id"])
+
         if method == "NfeAutorizacao":
             xml_send = signer.assina_xml(
                 xmlElem_send, kwargs["NFes"][0]["infNFe"]["Id"]
             )
+
         elif method == "RecepcaoEvento":
             xml_send = signer.assina_xml(xmlElem_send, kwargs["eventos"][0]["Id"])
+
         elif method == "RecepcaoEventoManifesto":
             xml_send = signer.assina_xml(
                 xmlElem_send, kwargs["manifesto"]["identificador"]
@@ -65,6 +69,7 @@ def _render(certificado, method, sign, **kwargs):
 
     else:
         xml_send = etree.tostring(xmlElem_send, encoding=str)
+
     return xml_send
 
 

--- a/pytrustnfe/nfe/assinatura.py
+++ b/pytrustnfe/nfe/assinatura.py
@@ -47,4 +47,10 @@ class Assinatura(object):
             elif element_signed is not None and signature is not None:
                 parent = element_signed.getparent()
                 parent.append(signature)
-        return etree.tostring(signed_root, encoding=str)
+
+        signed_root = etree.tostring(signed_root, encoding=str)
+
+        # Corrige erro 588
+        # Rejeicao: Nao eh permitida a presenca de caracteres de edicao no inicio/fim da mensagem ou entre as tags da mensagem (Elemento: enviNFe/NFe[1]/Signature/KeyInfo/X509Data/X509Certificate/)
+        # o SEFAZ passou a validar se a assinatura possui quebra de linha
+        return signed_root.replace('\n', '')


### PR DESCRIPTION
# Descrição

* Remove quebra de linha da assinatura da NFe

SEFAZ passou a validar a assinatura atrás de caracteres de quebra de linha.
Se a mesma possuir quebra de linha ocorre o seguinte erro:

588 - Rejeicao: Nao eh permitida a presenca de caracteres de edicao no inicio/fim da mensagem ou entre as tags da mensagem (Elemento: enviNFe/NFe[1]/Signature/KeyInfo/X509Data/X509Certificate/)

Este commit remove todas as quebras de linha presentes na assinatura.

# Informações adicionais

Dados da tarefa: [T8096](https://multi.multidados.tech/web#id=8505&action=323&active_id=61&model=project.task&view_type=form&menu_id=)

