### PR TITLE
T8197 - Erro na emissão de NFS-e de BH

### DIFF
--- a/pytrustnfe/nfse/bh/__init__.py
+++ b/pytrustnfe/nfse/bh/__init__.py
@@ -47,9 +47,9 @@ def _send(certificado, method, **kwargs):
     base_url = ""
 
     if kwargs["ambiente"] == "producao":
-        base_url = "https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl"
+        base_url = "https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl"
     else:
-        base_url = "https://bhisshomologa.pbh.gov.br/bhiss-ws/nfse?wsdl"
+        base_url = "https://bhisshomologaws.pbh.gov.br/bhiss-ws/nfse?wsdl"
 
     xml_send = kwargs["xml"]
     xml_cabecalho = '<?xml version="1.0" encoding="UTF-8"?>\


### PR DESCRIPTION
# Descrição

* Atualiza url do NFSE BH

# Informações adicionais

Dados da tarefa: [T8197](https://multi.multidados.tech/web?debug=#id=8606&action=328&model=project.task&view_type=form&menu_id=4)

