### PR TITLE
T8432 - Migração da base de codigo para Python 3.10

### DIFF
--- a/pytrustnfe/nfse/assinatura.py
+++ b/pytrustnfe/nfse/assinatura.py
@@ -2,7 +2,10 @@
 # © 2016 Danimar Ribeiro, Trustcode
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import signxml
 from lxml import etree
+
+# from lxml import etree
 import xmlsec
 import os.path
 

--- a/setup.py
+++ b/setup.py
@@ -51,17 +51,19 @@ later (LGPLv2+)",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     install_requires=[
-        'urllib3 >= 1.22',
-        'xmlsec >= 1.3.3',  # apt update;apt install libxmlsec1-dev pkg-config -y
-        'Jinja2 >= 2.8',
-        'pyOpenSSL >= 16.0.0, < 18',
-        'signxml >= 2.4.0',
-        'lxml >= 3.5.0, < 5',
-        'suds-jurko >= 0.6',
-        'suds-jurko-requests >= 1.2',
-        'reportlab',
-        'pytz',
-        'zeep',
+        # dependencias controladas pelo requirements.txt da raiz do projeto
+        # 'xmlsec >= 1.3.13',  # apt update;apt install libxmlsec1-dev pkg-config -y
+        # "signxml >= 3.2.2", # instala o lxml internamente (evita conflito de versoes)
+        # 'cryptography >= 3.4.8',
+        # 'pyOpenSSL >= 17.5.0, <= 23.2.0',
+        # 'certifi >=  2018.1.18',
+        # 'urllib3',
+        # 'Jinja2',
+        # 'suds-community',
+        # 'suds-requests4',
+        # 'reportlab',
+        # 'pytz',
+        # 'zeep',
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
# Descrição

* Migração para Python 3.10

Versao das dependencias sera controlada pelo requirements.txt do projeto

# Informações adicionais

Dados da tarefa: [T8432](https://multi.multidados.tech/web#id=8841&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

