### PR TITLE
T8742 - Erro de assinatura de XML no Python 3.10

### DIFF
--- a/pytrustnfe/nfe/assinatura.py
+++ b/pytrustnfe/nfe/assinatura.py
@@ -5,7 +5,7 @@
 import signxml
 from lxml import etree
 from pytrustnfe.certificado import extract_cert_and_key_from_pfx
-from signxml import XMLSigner
+from signxml import XMLSigner, SignatureMethod, DigestAlgorithm, CanonicalizationMethod
 
 
 class Assinatura(object):
@@ -22,9 +22,9 @@ class Assinatura(object):
 
         signer = XMLSigner(
             method=signxml.methods.enveloped,
-            signature_algorithm="rsa-sha1",
-            digest_algorithm="sha1",
-            c14n_algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+            signature_algorithm=SignatureMethod.RSA_SHA256,
+            digest_algorithm=DigestAlgorithm.SHA256,
+            c14n_algorithm=CanonicalizationMethod.CANONICAL_XML_1_1,
         )
 
         ns = {}


### PR DESCRIPTION
# Descrição

* Corrige algoritmo deprecated da assinatura do XML de nfe

Algoritmo SHA-1 esta deprecated e foi substitiuido por algoritmos mais seguros, conforme a mensagem da lib SignXML:

signxml.exceptions.InvalidInput: SHA1-based algorithms are not supported in the default configuration because they are not secure

# Informações adicionais

Dados da tarefa: [T8742](https://multi.multidados.tech/web#id=9151&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


