### PR TITLE
T9126 - Erro ao emitir nota para o exterior com CFOP interna

### DIFF
--- a/pytrustnfe/nfe/templates/NfeAutorizacao.xml
+++ b/pytrustnfe/nfe/templates/NfeAutorizacao.xml
@@ -111,7 +111,7 @@
             {% if NFe.infNFe.dest is defined %}
             <dest>
                 {% with dest = NFe.infNFe.dest %}
-                {% if NFe.infNFe.ide.idDest == '3' %}
+                {% if dest.idEstrangeiro %}
                     <idEstrangeiro>{{ dest.idEstrangeiro }}</idEstrangeiro>
                 {% endif %}
                 {% if NFe.infNFe.ide.idDest != '3' %}


### PR DESCRIPTION
# Descrição

Atualiza condição para exibir 'idEstrangeiro' no template NfeAutorizacao.xml

# Informações adicionais

Dados da tarefa: [T9126](https://multi.multidados.tech/web#id=9535&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


